### PR TITLE
Feat[28]: Incluir masa y gravedad en el calculo de fuerza

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bin/*
 profiling/*
 ejemplo_prints_c.c
 *.tree
+requirements.txt
+*.jl
+*.mp4

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,4 @@
 
 {
-    "dt" : 0.001,"nBodies" : 4096,"nIters" : 100
+    "dt" : 0.001,"nBodies" : 5120,"nIters" : 3000, "max_particles_speed": 20
 }

--- a/include/body.cuh
+++ b/include/body.cuh
@@ -1,5 +1,5 @@
 #ifndef BODY_CUH
 #define BODY_CUH
 
-typedef struct { float x, y, z, vx, vy, vz; } Body;
+typedef struct { float x, y, z, vx, vy, vz, fx, fy, fz, mass;} Body;
 #endif // BODY_CUH

--- a/include/bodyForce.cuh
+++ b/include/bodyForce.cuh
@@ -3,6 +3,7 @@
 #include "body.cuh"
 
 #define SOFTENING 1e-9f
+#define G 9.807
 
 __global__ void bodyForceCUDA(Body *p, float dt, int nBodies);
 

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -3,8 +3,9 @@
 #include <string> 
 
 extern float dt;
-extern int nBodies;
 extern int nIters;
+extern int nBodies;
+extern float max_particles_speed;
 extern const std::string data_directory;
 extern const std::string default_config_path;
 extern const std::string simulation_data_file_name;

--- a/include/integrateWraper.cuh
+++ b/include/integrateWraper.cuh
@@ -1,5 +1,5 @@
-#ifndef INTEGRATE_CUH
-#define INTEGRATE_CUH
+#ifndef INTEGRATE_WRAPPER_CUH
+#define INTEGRATE_WRAPPER_CUH
 #include "body.cuh"
 #include "deviceProps.cuh"
 
@@ -7,4 +7,4 @@ void initIntegrate(int &gridDimX, int &integrateBlockDimX, int &integrateStride,
 
 void execIntegrate(int nBodies, float dt, Body *p_device, int gridDimX, int integrateBlockDimX, int stride);
 
-#endif // INTEGRATE_CUH
+#endif // INTEGRATE_WRAPPER_CUH

--- a/include/mass.cuh
+++ b/include/mass.cuh
@@ -1,0 +1,8 @@
+#ifndef MASS_CUH
+#define MASS_CUH
+#include "body.cuh"
+#define MASS_SOFTENING 0.1
+
+__global__ void initialize_mass(Body* p_device, int nBodies);
+
+#endif // MASS_CUH

--- a/include/massWraper.cuh
+++ b/include/massWraper.cuh
@@ -1,0 +1,11 @@
+#ifndef MASS_WRAPPER_CUH
+#define MASS_WRAPPER_CUH
+#include "body.cuh"
+#include "deviceProps.cuh"
+
+void initMassKernelLaunch(int &gridDimX, int &massDimX, DeviceProperties deviceProps);
+void massKernelLaunch(int nBodies, Body *p_device, int gridDimX, int blockDimX);
+
+#endif // MASS_WRAPPER_CUH
+
+

--- a/include/velocity.cuh
+++ b/include/velocity.cuh
@@ -1,0 +1,9 @@
+#ifndef VELOCITY_CUH
+#define VELOCITY_CUH
+#include "body.cuh"
+#define VELOCITY_SOFTENING 0.1
+
+__global__ void initialize_velocity(Body* p_device, int nBodies, float max_particles_speed);
+
+#endif // VELOCITY_CUH
+

--- a/include/velocityWrapper.cuh
+++ b/include/velocityWrapper.cuh
@@ -1,0 +1,11 @@
+#ifndef VELOCITY_WRAPPER_CUH
+#define VELOCITY_WRAPPER_CUH
+#include "body.cuh"
+#include "deviceProps.cuh"
+
+void initVelocityKernelLaunch(int &gridDimX, int &VelocityDimX, DeviceProperties deviceProps);
+void velocityKernelLaunch(int nBodies, Body *p_device, int gridDimX, int blockDimX, float max_particles_speed);
+
+#endif // VELOCITY_WRAPPER_CUH
+
+

--- a/kernels/bodyForce.cu
+++ b/kernels/bodyForce.cu
@@ -9,19 +9,27 @@ __global__ void bodyForceCUDA(Body *p_device, float dt, int nBodies) {
         float Fx = 0.0f, Fy = 0.0f, Fz = 0.0f;
 
         for (int j = 0; j < nBodies; j++) {
-            float dx = p_device[j].x - p_device[i].x;
-            float dy = p_device[j].y - p_device[i].y;
-            float dz = p_device[j].z - p_device[i].z;
-            float distSqr = dx*dx + dy*dy + dz*dz + SOFTENING;
-            float invDist = rsqrtf(distSqr);
-            float invDist3 = invDist * invDist * invDist;
-            Fx += dx * invDist3;
-            Fy += dy * invDist3;
-            Fz += dz * invDist3;
-        }
+            if (i != j) {
+                float dx = p_device[j].x - p_device[i].x;
+                float dy = p_device[j].y - p_device[i].y;
+                float dz = p_device[j].z - p_device[i].z;
+                //& Δx^2 + Δy^2 +Δz^2 +ε
+                float distSqr = dx*dx + dy*dy + dz*dz + SOFTENING;
+                //& r^3
+                float distSixth = distSqr * sqrtf(distSqr);
 
-        p_device[i].vx += dt * Fx;
-        p_device[i].vy += dt * Fy;
-        p_device[i].vz += dt * Fz;
+                // Calculamos la magnitud de la fuerza gravitacional
+                float forceMag = G * p_device[i].mass * p_device[j].mass / distSixth;
+
+                // Ahora sumamos la contribución de la fuerza en cada componente
+                Fx += forceMag * dx;
+                Fy += forceMag * dy;
+                Fz += forceMag * dz;
+            }
+        }
+        // Guardamos las fuerzas acumuladas en cada componente
+        p_device[i].fx = Fx;
+        p_device[i].fy = Fy;
+        p_device[i].fz = Fz;
     }
 }

--- a/kernels/integrate.cu
+++ b/kernels/integrate.cu
@@ -6,6 +6,10 @@ __global__ void integrateCUDA(Body *p_device, float dt, int nBody, int stride)
   int index = threadIdx.x + blockIdx.x * blockDim.x;
   for(int i = index; i<nBody ; i+=stride)
   {
+      p_device[i].vx += dt * p_device[i].fx; //Integrar velocidades con las fuerzas calculadas.
+      p_device[i].vy += dt * p_device[i].fy;
+      p_device[i].vz += dt * p_device[i].fz;
+
       p_device[i].x += p_device[i].vx*dt;
       p_device[i].y += p_device[i].vy*dt;
       p_device[i].z += p_device[i].vz*dt;

--- a/kernels/mass.cu
+++ b/kernels/mass.cu
@@ -1,0 +1,20 @@
+#include "body.cuh"
+#include "mass.cuh"
+
+
+__global__ void initialize_mass(Body* p_device, int nBodies) {
+
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < nBodies) {
+        float dist = sqrtf(
+            (p_device[i].x) * (p_device[i].x) +
+            (p_device[i].y) * (p_device[i].y) +
+            (p_device[i].z) * (p_device[i].z)
+        );
+
+        // Por ejemplo, podrías definir la masa como inversamente proporcional a la distancia
+        p_device[i].mass = 1.0f / (dist + MASS_SOFTENING);
+
+        // p_device[i].mass = some_base_mass * exp(-dist * decay_factor);
+    }
+}

--- a/kernels/velocity.cu
+++ b/kernels/velocity.cu
@@ -1,0 +1,24 @@
+#include "body.cuh"
+#include "mass.cuh"
+
+
+__global__ void initialize_velocity(Body* p_device, int nBodies, float max_particles_speed) {
+
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i < nBodies) {
+        float dist = sqrtf(
+            p_device[i].x * p_device[i].x +
+            p_device[i].y * p_device[i].y +
+            p_device[i].z * p_device[i].z
+        );
+
+        // Definir la velocidad en función de la distancia al centro (para dar mayor velocidad a partículas cercanas)
+        float speed = max_particles_speed * (1.0f / (dist + 0.1f));  // +0.1f para evitar divisiones por cero
+
+        // Crear un vector tangencial para la velocidad
+        p_device[i].vx = -speed * p_device[i].y / dist;  // Velocidad tangente al eje Z
+        p_device[i].vy = speed * p_device[i].x / dist;   // Velocidad tangente al eje Z
+        p_device[i].vz = 0.0f;  // Queremos que las partículas formen un disco en el plano X-Y
+    }
+}

--- a/scripts/run_compilation.bat
+++ b/scripts/run_compilation.bat
@@ -12,14 +12,18 @@ set HOST_DIR= %SRC_DIR%\host
 :: Compilar los archivos
 nvcc -std=c++17 ^
 %DEVICE_DIR%\deviceProps.cu ^
-%DEVICE_DIR%\integrateWraper.cu ^
-%DEVICE_DIR%\bodyForceWraper.cu ^
 %DEVICE_DIR%\boxMullerWraper.cu ^
+%DEVICE_DIR%\massWraper.cu^
+%DEVICE_DIR%\velocityWrapper.cu ^
+%DEVICE_DIR%\bodyForceWraper.cu ^
+%DEVICE_DIR%\integrateWraper.cu ^
 %DEVICE_DIR%\data_collector.cu ^
 %SRC_DIR%\simulator.cu ^
-%KERNEL_DIR%\integrate.cu ^
-%KERNEL_DIR%\bodyForce.cu ^
 %KERNEL_DIR%\boxMuller.cu ^
+%KERNEL_DIR%\mass.cu ^
+%KERNEL_DIR%\velocity.cu ^
+%KERNEL_DIR%\bodyForce.cu ^
+%KERNEL_DIR%\integrate.cu ^
 %KERNEL_DIR%\memory_management.cu ^
 %HOST_DIR%\utils.cpp ^
 %HOST_DIR%\config.cpp ^

--- a/src/device/data_collector.cu
+++ b/src/device/data_collector.cu
@@ -8,7 +8,7 @@
 namespace fs = std::filesystem;
 
 void logSimulationData(Body* p, int nBodies, int iter) {
-    
+
     //* Definir la ruta del archivo
     std::string file_path = std::string(data_directory) + simulation_data_file_name;
 
@@ -35,13 +35,13 @@ void logSimulationData(Body* p, int nBodies, int iter) {
 
     //* Si el archivo es nuevo, escribir la cabecera
     if (!fileExists) {
-        csvFile << "Iteration,BodyID,PosX,PosY,PosZ,VelX,VelY,VelZ\n";
+        csvFile << "Iteration,BodyID,PosX,PosY,PosZ,VelX,VelY,VelZ,mass\n";
     }
 
     //* Escribir los datos de la simulación en el archivo
     for (int i = 0; i < nBodies; i++) {
         csvFile << iter << "," << i << "," << p[i].x << "," << p[i].y << "," << p[i].z << "," 
-                << p[i].vx << "," << p[i].vy << "," << p[i].vz << "\n";
+                << p[i].vx << "," << p[i].vy << "," << p[i].vz << "," << p[i].mass << "\n";
     }
 
     //* Cerrar el archivo

--- a/src/device/massWraper.cu
+++ b/src/device/massWraper.cu
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <cuda_runtime.h>
+#include <iostream>
+#include "body.cuh"
+#include "mass.cuh"
+#include "cuda_utils.cuh"
+#include "deviceProps.cuh"
+
+void initMassKernelLaunch(
+    int &gridDimX, 
+    int &massDimX, 
+    DeviceProperties deviceProps) {
+
+    gridDimX = 2*deviceProps.warpDim;
+    massDimX = deviceProps.warpDim * deviceProps.warpDim;
+    printf("INFO - gridDimX: %d, massDimX: %d\n", gridDimX, massDimX);
+}
+
+void massKernelLaunch(
+    int nBodies, 
+    Body *p_device, 
+    int gridDimX, 
+    int blockDimX) {
+
+    dim3 dimGrid(gridDimX, 1, 1);
+    dim3 massDimBlock(blockDimX, 1, 1);
+    initialize_mass<<<dimGrid, massDimBlock>>>(p_device, nBodies);
+    CHECK_CUDA_ERROR(cudaDeviceSynchronize());
+}

--- a/src/device/velocityWrapper.cu
+++ b/src/device/velocityWrapper.cu
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <cuda_runtime.h>
+#include <iostream>
+#include "body.cuh"
+#include "velocity.cuh"
+#include "cuda_utils.cuh"
+#include "deviceProps.cuh"
+
+void initVelocityKernelLaunch(
+    int &gridDimX, 
+    int &VelocityDimX, 
+    DeviceProperties deviceProps) {
+
+    gridDimX = 2*deviceProps.warpDim;
+    VelocityDimX = deviceProps.warpDim * deviceProps.warpDim;
+    printf("INFO - gridDimX: %d, VelocityDimX: %d\n", gridDimX, VelocityDimX);
+}
+
+void velocityKernelLaunch(
+    int nBodies, 
+    Body *p_device, 
+    int gridDimX, 
+    int blockDimX,
+    float max_particles_speed) {
+
+    dim3 dimGrid(gridDimX, 1, 1);
+    dim3 VelocityDimBlock(blockDimX, 1, 1);
+    initialize_velocity<<<dimGrid, VelocityDimBlock>>>(p_device, nBodies, max_particles_speed);
+    CHECK_CUDA_ERROR(cudaDeviceSynchronize());
+}

--- a/src/host/config.cpp
+++ b/src/host/config.cpp
@@ -10,8 +10,10 @@ const  std::string simulation_data_file_name = "simulation_data.csv";
 const  std::string default_config_path = "../config/config.json";
 
 float dt = 0.001f;
+float max_particles_speed = 1;
 int nBodies = 256;
 int nIters = 10;
+
 
 void load_config_from_file(const std::string& config_file) {
     std::ifstream file(config_file);
@@ -32,5 +34,8 @@ void load_config_from_file(const std::string& config_file) {
     }
     if (config.contains("dt")) {
         dt = config["dt"];
+    }
+    if (config.contains("max_particles_speed")) {
+        max_particles_speed = config["max_particles_speed"];
     }
 }


### PR DESCRIPTION
Este PR cierra #28, #24 y #40.

**Cambios realizados:**

**Incorporación de las masas y la constante de gravedad en la ecuación de cálculo de fuerzas:**
Las fuerzas entre partículas se calculan de manera más precisa.

**Reubicación de la integración numérica de velocidades (Euler explícito):**
Se ha movido esta operación al kernel adecuado. Anteriormente se realizaba en el kernel de cálculo de fuerzas, lo que no era una separación prolija de responsabilidades. 

**Inicialización de masas en función de su posición respecto al origen:**
Las masas ahora se determinan dinámicamente en función de la posición de las partículas, lo que permite simular sistemas con variabilidad en la distribución de masas.

**Inicialización de las velocidades rotacionales:**
Las velocidades de rotación de las partículas se calculan en función de su distancia al centro del sistema.